### PR TITLE
Document step for downloading dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ git clone git@github.com:jesusrp98/spacex-go.git
 
 Then, download either Android Studio or Visual Studio Code, with their respective [Flutter editor plugins](https://flutter.io/get-started/editor/). For more information about Flutter installation procedure, check the [official install guide](https://flutter.io/get-started/install/).
 
+Install dependencies from pubspec.yaml by running `flutter packages get` from the project root (see [using packages documentation](https://flutter.io/using-packages/#adding-a-package-dependency-to-an-app) for details and how to do this in the editor). 
+
 There you go, you can now open & edit the project. Enjoy!
 
 ## Built with


### PR DESCRIPTION
This step was missing when I tried to run in debugger, otherwise it worked fine. 