### PR TITLE
Change url to reduce image size, reduce memory consumption

### DIFF
--- a/lib/models/launch.dart
+++ b/lib/models/launch.dart
@@ -22,13 +22,15 @@ class LaunchesModel extends QueryModel {
 
   @override
   Future loadData([BuildContext context]) async {
-    // Clear old data
-    clearItems();
 
+    print("loading data..");
     // Fetch & add items
     List launches = await fetchData(
       type == 0 ? Url.upcomingList : Url.launchesList,
     );
+    
+    // Clear old data
+    clearItems();
 
     items.addAll(launches.map((launch) => Launch.fromJson(launch)).toList());
 

--- a/lib/models/launch.dart
+++ b/lib/models/launch.dart
@@ -112,7 +112,9 @@ class Launch {
     if (list.isEmpty)
       return SpaceXPhotos.spacexUpcomingScreen;
     else
-      return list;
+      // return list;
+      return list.map((oneUrl)=>oneUrl.toString().replaceRange(oneUrl.length-5,oneUrl.length-1, "m.jpg")).toList();
+
   }
 
   static DateTime setStaticFireDate(String date) {

--- a/lib/ui/tabs/launches.dart
+++ b/lib/ui/tabs/launches.dart
@@ -13,6 +13,7 @@ import '../../widgets/separator.dart';
 import '../../widgets/sliver_bar.dart';
 import '../pages/launch.dart';
 import '../search/launches.dart';
+import 'package:connectivity/connectivity.dart';
 
 /// LAUNCHES TAB VIEW
 /// This tab holds information a specific type of launches,
@@ -22,9 +23,29 @@ class LaunchesTab extends StatelessWidget {
 
   LaunchesTab(this.title);
 
-  Future<Null> _onRefresh(LaunchesModel model) {
+  Future<Null> _onRefresh(LaunchesModel model, BuildContext context) async {
+    var connectivityResult = await (Connectivity().checkConnectivity());
     Completer<Null> completer = Completer<Null>();
-    model.refresh().then((_) => completer.complete());
+
+    if (connectivityResult == ConnectivityResult.mobile ||
+        connectivityResult == ConnectivityResult.wifi) {
+      print("Connected to a network");
+      model.refresh().then((_) => completer.complete());
+    } else {
+      print("Unable to connect. Please Check Internet Connection");
+
+      completer.complete();
+      //snackbar informing no connectivity
+      final snackBar = SnackBar(
+          content: Text('No internet connection, cannot reload.'),
+          action: SnackBarAction(
+            label: 'OK',
+            onPressed: () {
+              // Some code to undo the change!
+            },
+          ));
+      Scaffold.of(context).showSnackBar(snackBar);
+    }
     return completer.future;
   }
 
@@ -33,7 +54,7 @@ class LaunchesTab extends StatelessWidget {
     return ScopedModelDescendant<LaunchesModel>(
       builder: (context, child, model) => Scaffold(
             body: RefreshIndicator(
-              onRefresh: () => _onRefresh(model),
+              onRefresh: () => _onRefresh(model, context),
               child: CustomScrollView(
                   key: PageStorageKey('spacex_launches_$title'),
                   slivers: <Widget>[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,9 @@ dependencies:
   ## Icons
   font_awesome_flutter: ^8.4.0
 
+  ##To check for internet connection
+  connectivity: 
+
 flutter:
   fonts:
     - family: RobotoMono


### PR DESCRIPTION
This is a short code snippet to demonstrate the proof of concept solution. It only works for the "latest" section of the app for the moment. It reduces the image size to medium (max width or height of 240). More info [here](https://www.flickr.com/services/api/misc.urls.html).

## Connection with issue(s)

Example of a possible solution to issue #37 

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->
The way I tested it was to use the [dart devtools](https://flutter.github.io/devtools/) to profile the memory consumption. 

Make sure to run it in profiler mode to get an approximate measure of the apps behavior in production .

## Screenshots or Videos
This changes the memory consumption from +- 300Mb:
![image](https://user-images.githubusercontent.com/30906976/57533963-90540680-7304-11e9-8b67-d5627a9337e1.png)

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->
To +- 200Mb.
![image](https://user-images.githubusercontent.com/30906976/57533984-9ba73200-7304-11e9-9b1e-7035f6e01643.png)



## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] Extend solution to all tabs appart from "latest"
- [ ] See memory consumption drop when previous item is completed
- [ ] Set option in settings where users can select image quality. 
